### PR TITLE
Replace V2 of Terraform Bridge for downstream testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - name: Install Python
+        uses: actions/setup-python@v1
         with:
           python-version: 3.6.10
-      - uses: actions/checkout@v1
+      - name: Install tf2pulumi
+        uses: pulumi/action-install-tf2pulumi@releases/v1
+      - name: Check Out Sources
+        uses: actions/checkout@v1
 
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - run: git clone https://github.com/pulumi/pulumi-terraform-bridge ../pulumi-terraform-bridge
-      - uses: ./
+
+      - name: Clone Terraform bridge repository
+        run: git clone https://github.com/pulumi/pulumi-terraform-bridge ../pulumi-terraform-bridge
+      - name: Test Action on pulumi-vault repository
+        uses: ./
         env:
           GOPROXY: "https://proxy.golang.org"
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `test-provider-downstream` GitHub Action
 
-This repository contains a GitHub Action for testing the effects of [`pulumi-terraform-bridge`][[1] changes on downstream providers.
+This repository contains a GitHub Action for testing the effects of [`pulumi-terraform-bridge`][1] changes on downstream providers.
 
 This is not generally useful outside of Pulumi Development. For usage guidance, see the [CI workflow][2] in `pulumi-terraform-bridge`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
     },
     "@actions/exec": {
       "version": "1.0.3",
@@ -18,12 +18,81 @@
       }
     },
     "@actions/github": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-1.1.0.tgz",
-      "integrity": "sha512-cHf6PyoNMdei13jEdGPhKprIMFmjVVW/dnM5/9QmQDJ1ZTaGVyezUSCUIC/ySNLRvDUpeFwPYMdThSEJldSbUw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.1.tgz",
+      "integrity": "sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==",
       "requires": {
-        "@octokit/graphql": "^2.0.1",
-        "@octokit/rest": "^16.15.0"
+        "@actions/http-client": "^1.0.3",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/rest": "^16.43.1"
+      },
+      "dependencies": {
+        "@octokit/plugin-paginate-rest": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+          "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+          "requires": {
+            "@octokit/types": "^2.0.1"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+          "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+          "requires": {
+            "@octokit/types": "^2.0.1",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+          "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+          "requires": {
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/rest": {
+          "version": "16.43.1",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
+          "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+          "requires": {
+            "@octokit/auth-token": "^2.4.0",
+            "@octokit/plugin-paginate-rest": "^1.1.1",
+            "@octokit/plugin-request-log": "^1.0.0",
+            "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+            "@octokit/request": "^5.2.0",
+            "@octokit/request-error": "^1.0.2",
+            "atob-lite": "^2.0.0",
+            "before-after-hook": "^2.0.0",
+            "btoa-lite": "^1.0.0",
+            "deprecation": "^2.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^4.0.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.7.tgz",
+      "integrity": "sha512-PY3ys/XH5WMekkHyZhYSa/scYvlE5T/TV/T++vABHuY5ZRgtiBZkn2L2tV5Pv/xDCl59lSZb9WwRuWExDyAsSg==",
+      "requires": {
+        "tunnel": "0.0.6"
       }
     },
     "@actions/io": {
@@ -31,136 +100,86 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
-    "@octokit/endpoint": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz",
-      "integrity": "sha512-TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==",
+    "@octokit/auth-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
+      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
       "requires": {
-        "@octokit/types": "^1.0.0",
+        "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.0.tgz",
+      "integrity": "sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
         "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
+      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
         "universal-user-agent": "^4.0.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-        },
         "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
           "requires": {
             "os-name": "^3.1.0"
           }
         }
       }
     },
-    "@octokit/graphql": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.1.3.tgz",
-      "integrity": "sha512-XoXJqL2ondwdnMIW3wtqJWEwcBfKk37jO/rYkoxNPEVeLBDGsGO1TCWggrAlq3keGt/O+C/7VepXnukUxwt5vA==",
-      "requires": {
-        "@octokit/request": "^5.0.0",
-        "universal-user-agent": "^2.0.3"
-      }
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
     },
     "@octokit/request": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.0.tgz",
-      "integrity": "sha512-mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.0.tgz",
+      "integrity": "sha512-uAJO6GI8z8VHBqtY7VTL9iFy1Y+UTp5ShpI97tY5z0qBfYKE9rZCRsCm23VmF00x+IoNJ7a0nuVITs/+wS9/mg==",
       "requires": {
-        "@octokit/endpoint": "^5.5.0",
-        "@octokit/request-error": "^1.0.1",
-        "@octokit/types": "^1.0.0",
+        "@octokit/endpoint": "^6.0.0",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^2.8.2",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-        },
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/request-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
-      "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
       "requires": {
+        "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
-    "@octokit/rest": {
-      "version": "16.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.0.tgz",
-      "integrity": "sha512-EBe5qMQQOZRuezahWCXCnSe0J6tAqrW2hrEH9U8esXzKor1+HUDf8jgImaZf5lkTyWCQA296x9kAH5c0pxEgVQ==",
-      "requires": {
-        "@octokit/request": "^5.2.0",
-        "@octokit/request-error": "^1.0.2",
-        "atob-lite": "^2.0.0",
-        "before-after-hook": "^2.0.0",
-        "btoa-lite": "^1.0.0",
-        "deprecation": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
-      },
-      "dependencies": {
-        "universal-user-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-          "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
-        }
-      }
-    },
     "@octokit/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.10.0.tgz",
+      "integrity": "sha512-0/NN22MgQvNNgMjTwzWUzcIfFfks3faqiP1D1oQQz49KYeOWc+KkRG9ASbAPurrAnOaDiqnnuDYzhNT9cq4e8Q==",
       "requires": {
-        "@types/node": "^12.11.1"
+        "@types/node": ">= 8"
       }
     },
     "@types/node": {
-      "version": "12.12.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.28.tgz",
-      "integrity": "sha512-g73GJYJDXgf0jqg+P9S8h2acWbDXNkoCX8DLtJVu7Fkn788pzQ/oJsrdJz/2JejRf/SjfZaAhsw+3nd1D5EWGg=="
+      "version": "12.12.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
+      "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
     },
     "atob-lite": {
       "version": "2.0.0",
@@ -224,6 +243,14 @@
         "pump": "^3.0.0"
       }
     },
+    "is-plain-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "requires": {
+        "isobject": "^4.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -233,6 +260,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -332,27 +364,32 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "typescript": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "universal-user-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
-      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
       "requires": {
-        "os-name": "^3.0.0"
+        "os-name": "^3.1.0"
       }
     },
     "which": {
@@ -364,9 +401,9 @@
       }
     },
     "windows-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
       "requires": {
         "execa": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "author": "Pulumi Corporation",
   "license": "Apache2.0",
   "dependencies": {
-    "@actions/core": "^1.2.2",
+    "@actions/core": "^1.2.3",
     "@actions/exec": "^1.0.3",
-    "@actions/github": "^1.1.0"
+    "@actions/github": "^2.1.1"
   },
   "devDependencies": {
-    "@types/node": "^12.12.28",
-    "typescript": "^3.8.2"
+    "@types/node": "^12.12.35",
+    "typescript": "^3.8.3"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
-import * as github from "@actions/github";
 import {exec} from "@actions/exec";
+import * as github from "@actions/github";
 import * as path from "path";
 
 async function find_gopath(): Promise<string> {
@@ -35,7 +35,7 @@ async function run() {
         const checkoutSHA = process.env.GITHUB_SHA;
         const branchName = `integration/pulumi-terraform-bridge/${checkoutSHA}`;
 
-        const replace = "github.com/pulumi/pulumi-terraform-bridge";
+        const replace = "github.com/pulumi/pulumi-terraform-bridge/v2";
         let replaceWith = "../pulumi-terraform-bridge";
         const gitUser = "Pulumi Bot";
         const gitEmail = "bot@pulumi.com";
@@ -118,7 +118,7 @@ async function run() {
                 owner: github.context.issue.owner,
                 repo: github.context.issue.repo,
                 issue_number: github.context.issue.number,
-                body: `Diff for [${downstreamName}](${diffUrl}) with commit ${checkoutSHA}`,
+                body: `Diff for [${downstreamName}](${diffUrl}) with merge commit ${checkoutSHA}`,
             });
         } else {
             await exec("git", ["show"], inDownstreamOptions);


### PR DESCRIPTION
As import paths change with major versions in Go Modules, it's necessary to replace `v2` instead of `v1` of the Terraform bridge, else no replacement takes effect. This is the root cause of the lack of diffs being thrown up in pulumi/pulumi-terraform-bridge#161.