### PR TITLE
Folding + Warn (or fail) on fatal examples

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     deprecationMessage: 'Use a github action to create a comment or view the job summary instead.'
     description: 'Issue to comment on'
     required: false
+  enforce-fatal:
+    description: 'If the action should fail when encountering fatal errors during codegen.'
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -126,9 +126,13 @@ function run() {
                 const json = JSON.parse(f.toString());
                 const fatals = json.Fatals.Number;
                 if (fatals > 0) {
-                    core.setFailed(`Found ${fatals} fatal errors during codegen`);
+                    if (core.getBooleanInput("enforce-fatal", { required: false }))
+                        core.setFailed(`Found ${fatals} fatal errors during codegen`);
+                    else
+                        core.warning("${fatals} examples crashed codegen");
+                    delete json["ConversionErrors"];
+                    core.summary.addRaw(json);
                 }
-                core.summary.addRaw(fs.readFileSync(`${summaryDir}/summary.json`).toString());
             }
             catch (err) {
                 // Not all providers have a summary, so if no file gets generated, we do nothing

--- a/lib/main.js
+++ b/lib/main.js
@@ -103,7 +103,7 @@ function run() {
                 env: Object.assign(Object.assign({}, process.env), { PATH: newPath }),
             };
             const inDownstreamModOptions = Object.assign(Object.assign({}, inDownstreamOptions), { cwd: downstreamModDirFull });
-            yield (0, exec_1.exec)("git", ["clone", downstreamRepo, downstreamDir]);
+            yield (0, exec_1.exec)("git", ["clone", "--quiet", downstreamRepo, downstreamDir]);
             yield (0, exec_1.exec)("git", ["checkout", "-b", branchName], inDownstreamOptions);
             yield (0, exec_1.exec)("git", ["config", "user.name", gitUser], inDownstreamOptions);
             yield (0, exec_1.exec)("git", ["config", "user.email", gitEmail], inDownstreamOptions);
@@ -112,11 +112,15 @@ function run() {
                 core.info(`replacing ${replace.module} with ${replace.with} @ ${replacePath}`);
                 yield (0, exec_1.exec)("go", ["mod", "edit", `-replace=${replace.module}=${replacePath}`], inDownstreamModOptions);
             }
+            console.log("::group::go mod tidy");
             yield (0, exec_1.exec)("go", ["mod", "tidy", "-compat=1.17"], inDownstreamModOptions);
+            console.log("::endgroup::");
             yield (0, exec_1.exec)("git", ["commit", "-a", "-m", `Replace ${upstream} module`], inDownstreamOptions);
-            const summaryDir = "summary";
+            const summaryDir = `${downstreamDir}/summary`;
             yield io.mkdirP(summaryDir);
+            console.log("::group::make only_build");
             yield (0, exec_1.exec)("make", ["only_build"], Object.assign(Object.assign({}, inDownstreamOptions), { env: Object.assign(Object.assign({}, inDownstreamOptions.env), { COVERAGE_OUTPUT_DIR: summaryDir }) }));
+            console.log("::endgroup::");
             try {
                 const f = fs.readFileSync(`${summaryDir}/summary.json`);
                 const json = JSON.parse(f.toString());
@@ -130,8 +134,13 @@ function run() {
                 // Not all providers have a summary, so if no file gets generated, we do nothing
                 if (err instanceof Error) {
                     const e = err;
-                    if (e.code !== 'ENOENT')
+                    if (e.code !== 'ENOENT') {
                         throw err;
+                    }
+                    else {
+                        console.log("No summary found.");
+                    }
+                    ;
                 }
             }
             yield (0, exec_1.exec)("git", ["add", "."], inDownstreamOptions);

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const exec_1 = require("@actions/exec");
+const io = __importStar(require("@actions/io"));
 const path = __importStar(require("path"));
+const fs = __importStar(require("fs"));
 function find_gopath() {
     return __awaiter(this, void 0, void 0, function* () {
         let output = "";
@@ -112,7 +114,26 @@ function run() {
             }
             yield (0, exec_1.exec)("go", ["mod", "tidy", "-compat=1.17"], inDownstreamModOptions);
             yield (0, exec_1.exec)("git", ["commit", "-a", "-m", `Replace ${upstream} module`], inDownstreamOptions);
-            yield (0, exec_1.exec)("make", ["only_build"], inDownstreamOptions);
+            const summaryDir = "summary";
+            yield io.mkdirP(summaryDir);
+            yield (0, exec_1.exec)("make", ["only_build"], Object.assign(Object.assign({}, inDownstreamOptions), { env: Object.assign(Object.assign({}, inDownstreamOptions.env), { COVERAGE_OUTPUT_DIR: summaryDir }) }));
+            try {
+                const f = fs.readFileSync(`${summaryDir}/summary.json`);
+                const json = JSON.parse(f.toString());
+                const fatals = json.Fatals.Number;
+                if (fatals > 0) {
+                    core.setFailed(`Found ${fatals} fatal errors during codegen`);
+                }
+                core.summary.addRaw(fs.readFileSync(`${summaryDir}/summary.json`).toString());
+            }
+            catch (err) {
+                // Not all providers have a summary, so if no file gets generated, we do nothing
+                if (err instanceof Error) {
+                    const e = err;
+                    if (e.code !== 'ENOENT')
+                        throw err;
+                }
+            }
             yield (0, exec_1.exec)("git", ["add", "."], inDownstreamOptions);
             yield (0, exec_1.exec)("git", ["commit", "--allow-empty", "-m", `Update to ${upstream}@${checkoutSHA}`], inDownstreamOptions);
             if (hasPullRequestToken) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,9 +129,13 @@ async function run() {
             const json = JSON.parse(f.toString());
             const fatals = json.Fatals.Number;
             if (fatals > 0) {
-                core.setFailed(`Found ${fatals} fatal errors during codegen`);
+                if (core.getBooleanInput("enforce-fatal", { required: false }))
+                    core.setFailed(`Found ${fatals} fatal errors during codegen`);
+                else
+                    core.warning("${fatals} examples crashed codegen");
+                delete json["ConversionErrors"];
+                core.summary.addRaw(json);
             }
-            core.summary.addRaw(fs.readFileSync(`${summaryDir}/summary.json`).toString());
         } catch (err) {
             // Not all providers have a summary, so if no file gets generated, we do nothing
             if (err instanceof Error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,16 +119,19 @@ async function run() {
             }});
 
         try {
-            const f = await fs.readFile(`${summaryDir}/summary.json`);
-            const json = JSON.parse(f);
+            const f = fs.readFileSync(`${summaryDir}/summary.json`);
+            const json = JSON.parse(f.toString());
             const fatals = json.Fatals.Number;
             if (fatals > 0) {
                 core.setFailed(`Found ${fatals} fatal errors during codegen`);
             }
-            core.summary.addRaw(await fs.readFile(`${summaryDir}/summary.json`));
+            core.summary.addRaw(fs.readFileSync(`${summaryDir}/summary.json`).toString());
         } catch (err) {
             // Not all providers have a summary, so if no file gets generated, we do nothing
-            if (err.code !== 'ENOENT') throw err;
+            if (err instanceof Error) {
+                const e: any = err;
+                if (e.code !== 'ENOENT') throw err;
+            }
         }
 
         await exec("git", ["add", "."], inDownstreamOptions);


### PR DESCRIPTION
This PR makes 2 improvements:
- It folds the output of `go mod tidy` and `make build_only`, so that summary data is visible without excessive scroll-down.
- It Adds a warning for fatal errors (crashing) during generation. There is also a flag `enforce-fatal` which turns these warnings into errors.