### PR TITLE
Remove old sdk files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -118,8 +118,9 @@ function run() {
             yield (0, exec_1.exec)("git", ["commit", "-a", "-m", `Replace ${upstream} module`], inDownstreamOptions);
             const summaryDir = `${downstreamDir}/summary`;
             yield io.mkdirP(summaryDir);
-            const sdkDir = "./sdk";
-            console.log(`Deleting ${sdkDir}/<LANG> folders`);
+            // Delete old sdk's to prevent un-deleted files error-ing compilation.
+            const sdkDir = `${downstreamDir}/sdk`;
+            console.log(`Deleting ${sdkDir}/LANG folders`);
             fs.readdirSync(sdkDir).filter(f => fs.statSync(`${sdkDir}/${f}`).isDirectory())
                 .forEach(dir => {
                 fs.rmSync(`${sdkDir}/${dir}`, { recursive: true, force: true });

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,6 +118,12 @@ function run() {
             yield (0, exec_1.exec)("git", ["commit", "-a", "-m", `Replace ${upstream} module`], inDownstreamOptions);
             const summaryDir = `${downstreamDir}/summary`;
             yield io.mkdirP(summaryDir);
+            const sdkDir = "./sdk";
+            console.log(`Deleting ${sdkDir}/<LANG> folders`);
+            fs.readdirSync(sdkDir).filter(f => fs.statSync(`${sdkDir}/${f}`).isDirectory())
+                .forEach(dir => {
+                fs.rmSync(`${sdkDir}/${dir}`, { recursive: true, force: true });
+            });
             console.log("::group::make only_build");
             yield (0, exec_1.exec)("make", ["only_build"], Object.assign(Object.assign({}, inDownstreamOptions), { env: Object.assign(Object.assign({}, inDownstreamOptions.env), { COVERAGE_OUTPUT_DIR: summaryDir }) }));
             console.log("::endgroup::");

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,13 @@ async function run() {
         const summaryDir = `${downstreamDir}/summary`
         await io.mkdirP(summaryDir);
 
+        const sdkDir = `${downstreamDir}/sdk`;
+        console.log(`Deleting ${sdkDir}/LANG folders`);
+        fs.readdirSync(sdkDir).filter(f => fs.statSync(`${sdkDir}/${f}`).isDirectory())
+            .forEach(dir => {
+            fs.rmSync(`${sdkDir}/${dir}`, { recursive: true, force: true });
+        });
+
         console.log("::group::make only_build");
         await exec("make", ["only_build"], {
             ...inDownstreamOptions,

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,7 @@ async function run() {
         const summaryDir = `${downstreamDir}/summary`
         await io.mkdirP(summaryDir);
 
+        // Delete old sdk's to prevent un-deleted files error-ing compilation.
         const sdkDir = `${downstreamDir}/sdk`;
         console.log(`Deleting ${sdkDir}/LANG folders`);
         fs.readdirSync(sdkDir).filter(f => fs.statSync(`${sdkDir}/${f}`).isDirectory())


### PR DESCRIPTION
This makes sure we aren't failing to compile because of old files.