### PR TITLE
Clone downstream with submodules

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -103,7 +103,7 @@ function run() {
                 env: Object.assign(Object.assign({}, process.env), { PATH: newPath }),
             };
             const inDownstreamModOptions = Object.assign(Object.assign({}, inDownstreamOptions), { cwd: downstreamModDirFull });
-            yield (0, exec_1.exec)("git", ["clone", "--quiet", downstreamRepo, downstreamDir]);
+            yield (0, exec_1.exec)("git", ["clone", "--recurse-submodules", "--quiet", downstreamRepo, downstreamDir]);
             yield (0, exec_1.exec)("git", ["checkout", "-b", branchName], inDownstreamOptions);
             yield (0, exec_1.exec)("git", ["config", "user.name", gitUser], inDownstreamOptions);
             yield (0, exec_1.exec)("git", ["config", "user.email", gitEmail], inDownstreamOptions);

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ async function run() {
             cwd: downstreamModDirFull,
         };
 
-        await exec("git", ["clone", "--quiet", downstreamRepo, downstreamDir]);
+        await exec("git", ["clone", "--recurse-submodules", "--quiet", downstreamRepo, downstreamDir]);
 
         await exec("git", ["checkout", "-b", branchName], inDownstreamOptions);
         await exec("git", ["config", "user.name", gitUser], inDownstreamOptions);


### PR DESCRIPTION
Clones the downstream repository with `--recurse-submodules`
which will check out all submodules in the repository
after cloning.

This is necessary because pulumi-aws now uses submodules
(https://github.com/pulumi/pulumi-aws/pull/2247).

Resolves pulumi/pulumi#12115
Resolves #15
